### PR TITLE
QUIC/SCION protocol version

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -64,6 +64,10 @@ const MaxPacketBufferSize ByteCount = 1452
 // MinInitialPacketSize is the minimum size an Initial packet is required to have.
 const MinInitialPacketSize = 1200
 
+// MinSCIONInitialPacketSize is the minimum size an Initial packet is required to have
+// in the SCION version of the protocol.
+const MinSCIONInitialPacketSize = 600
+
 // MinUnknownVersionPacketSize is the minimum size a packet with an unknown version
 // needs to have in order to trigger a Version Negotiation packet.
 const MinUnknownVersionPacketSize = MinInitialPacketSize

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,16 +18,32 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	VersionTLS      VersionNumber = 0x1
-	VersionWhatever VersionNumber = math.MaxUint32 - 1 // for when the version doesn't matter
-	VersionUnknown  VersionNumber = math.MaxUint32
-	VersionDraft29  VersionNumber = 0xff00001d
-	Version1        VersionNumber = 0x1
+	VersionTLS               VersionNumber = 0x1
+	VersionWhatever          VersionNumber = math.MaxUint32 - 1 // for when the version doesn't matter
+	VersionUnknown           VersionNumber = math.MaxUint32
+	VersionDraft29           VersionNumber = 0xff00001d
+	Version1                 VersionNumber = 0x1
+	VersionSCIONExperimental VersionNumber = 0x5c10000f
 )
 
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
-var SupportedVersions = []VersionNumber{Version1, VersionDraft29}
+var SupportedVersions = []VersionNumber{
+	VersionSCIONExperimental,
+	Version1,
+	VersionDraft29,
+}
+
+func IsSCIONVersion(v VersionNumber) bool {
+	return v >= 0x5c100000 && v <= 0x5c10000f
+}
+
+func GetMinInitialPacketSize(v VersionNumber) ByteCount {
+	if IsSCIONVersion(v) {
+		return MinSCIONInitialPacketSize
+	}
+	return MinInitialPacketSize
+}
 
 // IsValidVersion says if the version is known to quic-go
 func IsValidVersion(v VersionNumber) bool {
@@ -48,6 +64,8 @@ func (vn VersionNumber) String() string {
 		return "unknown"
 	case VersionDraft29:
 		return "draft-29"
+	case VersionSCIONExperimental:
+		return "scion-experimental"
 	case Version1:
 		return "v1"
 	default:

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -111,8 +111,8 @@ func (p *packetContents) ToAckHandlerPacket(now time.Time, q *retransmissionQueu
 	}
 }
 
-func getMaxPacketSize(addr net.Addr) protocol.ByteCount {
-	maxSize := protocol.ByteCount(protocol.MinInitialPacketSize)
+func getMaxPacketSize(addr net.Addr, version protocol.VersionNumber) protocol.ByteCount {
+	maxSize := protocol.GetMinInitialPacketSize(version)
 	// If this is not a UDP address, we don't know anything about the MTU.
 	// Use the minimum size of an Initial packet as the max packet size.
 	if udpAddr, ok := addr.(*net.UDPAddr); ok {
@@ -200,7 +200,7 @@ func newPacketPacker(
 		framer:              framer,
 		acks:                acks,
 		pnManager:           packetNumberManager,
-		maxPacketSize:       getMaxPacketSize(remoteAddr),
+		maxPacketSize:       getMaxPacketSize(remoteAddr, version),
 	}
 }
 
@@ -370,7 +370,7 @@ func (p *packetPacker) initialPaddingLen(frames []ackhandler.Frame, size protoco
 func (p *packetPacker) PackCoalescedPacket() (*coalescedPacket, error) {
 	maxPacketSize := p.maxPacketSize
 	if p.perspective == protocol.PerspectiveClient {
-		maxPacketSize = protocol.MinInitialPacketSize
+		maxPacketSize = protocol.GetMinInitialPacketSize(p.version)
 	}
 	var initialHdr, handshakeHdr, appDataHdr *wire.ExtendedHeader
 	var initialPayload, handshakePayload, appDataPayload *payload

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -114,18 +114,18 @@ var _ = Describe("Packet packer", func() {
 
 	Context("determining the maximum packet size", func() {
 		It("uses the minimum initial size, if it can't determine if the remote address is IPv4 or IPv6", func() {
-			Expect(getMaxPacketSize(&net.TCPAddr{})).To(BeEquivalentTo(protocol.MinInitialPacketSize))
+			Expect(getMaxPacketSize(&net.TCPAddr{}, protocol.Version1)).To(BeEquivalentTo(protocol.MinInitialPacketSize))
 		})
 
 		It("uses the maximum IPv4 packet size, if the remote address is IPv4", func() {
 			addr := &net.UDPAddr{IP: net.IPv4(11, 12, 13, 14), Port: 1337}
-			Expect(getMaxPacketSize(addr)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv4))
+			Expect(getMaxPacketSize(addr, protocol.Version1)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv4))
 		})
 
 		It("uses the maximum IPv6 packet size, if the remote address is IPv6", func() {
 			ip := net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
 			addr := &net.UDPAddr{IP: ip, Port: 1337}
-			Expect(getMaxPacketSize(addr)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv6))
+			Expect(getMaxPacketSize(addr, protocol.Version1)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv6))
 		})
 	})
 

--- a/server.go
+++ b/server.go
@@ -350,7 +350,7 @@ func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer s
 	if !hdr.IsLongHeader {
 		panic(fmt.Sprintf("misrouted packet: %#v", hdr))
 	}
-	if hdr.Type == protocol.PacketTypeInitial && p.Size() < protocol.MinInitialPacketSize {
+	if hdr.Type == protocol.PacketTypeInitial && p.Size() < protocol.GetMinInitialPacketSize(hdr.Version) {
 		s.logger.Debugf("Dropping a packet that is too small to be a valid Initial (%d bytes)", p.Size())
 		if s.config.Tracer != nil {
 			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeInitial, p.Size(), logging.PacketDropUnexpectedPacket)

--- a/session.go
+++ b/session.go
@@ -285,7 +285,7 @@ var newSession = func(
 	s.ctx, s.ctxCancel = context.WithCancel(context.WithValue(context.Background(), SessionTracingKey, tracingID))
 	s.sentPacketHandler, s.receivedPacketHandler = ackhandler.NewAckHandler(
 		0,
-		getMaxPacketSize(s.conn.RemoteAddr()),
+		getMaxPacketSize(s.conn.RemoteAddr(), s.version),
 		s.rttStats,
 		s.perspective,
 		s.tracer,
@@ -412,7 +412,7 @@ var newClientSession = func(
 	s.ctx, s.ctxCancel = context.WithCancel(context.WithValue(context.Background(), SessionTracingKey, tracingID))
 	s.sentPacketHandler, s.receivedPacketHandler = ackhandler.NewAckHandler(
 		initialPacketNumber,
-		getMaxPacketSize(s.conn.RemoteAddr()),
+		getMaxPacketSize(s.conn.RemoteAddr(), s.version),
 		s.rttStats,
 		s.perspective,
 		s.tracer,
@@ -815,7 +815,7 @@ func (s *session) handleHandshakeConfirmed() {
 		maxPacketSize = utils.MinByteCount(maxPacketSize, protocol.MaxPacketBufferSize)
 		s.mtuDiscoverer = newMTUDiscoverer(
 			s.rttStats,
-			getMaxPacketSize(s.conn.RemoteAddr()),
+			getMaxPacketSize(s.conn.RemoteAddr(), s.version),
 			maxPacketSize,
 			func(size protocol.ByteCount) {
 				s.sentPacketHandler.SetMaxDatagramSize(size)


### PR DESCRIPTION
1. Introduction of the new version number
2. In SCION version of the protocol minimal initial packet size is
       reduced from 1200B to 600B

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/quic-go/1)
<!-- Reviewable:end -->
