### PR TITLE
protocol: reorder the version priority

### DIFF
--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,18 +18,28 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	VersionTLS               VersionNumber = 0x1
-	VersionWhatever          VersionNumber = math.MaxUint32 - 1 // for when the version doesn't matter
-	VersionUnknown           VersionNumber = math.MaxUint32
-	VersionDraft29           VersionNumber = 0xff00001d
-	Version1                 VersionNumber = 0x1
+	VersionTLS      VersionNumber = 0x1
+	VersionWhatever VersionNumber = math.MaxUint32 - 1 // for when the version doesn't matter
+	VersionUnknown  VersionNumber = math.MaxUint32
+	VersionDraft29  VersionNumber = 0xff00001d
+	Version1        VersionNumber = 0x1
+
 	VersionSCIONExperimental VersionNumber = 0x5c10000f
 )
 
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
 var SupportedVersions = []VersionNumber{
+	Version1,
+	VersionDraft29,
+	// Prefer the native versions over SCIONExperimental to keep the default
+	// configuration backwards compatible.
 	VersionSCIONExperimental,
+}
+
+// NativeSuppertedVersions lists the versions that are natively
+// supported by upstream quic-go.
+var NativeSuppertedVersions = []VersionNumber{
 	Version1,
 	VersionDraft29,
 }


### PR DESCRIPTION
Use the native versions first, before using the SCION version, by default. This
is required to keep backwards compatibility when using the default client
configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/quic-go/2)
<!-- Reviewable:end -->
