### PR TITLE
QUIC/SCION protocol version

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -275,14 +275,14 @@ var newConnection = func(
 	s.ctx, s.ctxCancel = context.WithCancelCause(context.WithValue(context.Background(), ConnectionTracingKey, tracingID))
 	s.sentPacketHandler, s.receivedPacketHandler = ackhandler.NewAckHandler(
 		0,
-		getMaxPacketSize(s.conn.RemoteAddr()),
+		getMaxPacketSize(s.conn.RemoteAddr(), s.version),
 		s.rttStats,
 		clientAddressValidated,
 		s.perspective,
 		s.tracer,
 		s.logger,
 	)
-	s.mtuDiscoverer = newMTUDiscoverer(s.rttStats, getMaxPacketSize(s.conn.RemoteAddr()), s.sentPacketHandler.SetMaxDatagramSize)
+	s.mtuDiscoverer = newMTUDiscoverer(s.rttStats, getMaxPacketSize(s.conn.RemoteAddr(), s.version), s.sentPacketHandler.SetMaxDatagramSize)
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamReceiveWindow),
 		InitialMaxStreamDataBidiRemote:  protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -383,14 +383,14 @@ var newClientConnection = func(
 	s.ctx, s.ctxCancel = context.WithCancelCause(context.WithValue(context.Background(), ConnectionTracingKey, tracingID))
 	s.sentPacketHandler, s.receivedPacketHandler = ackhandler.NewAckHandler(
 		initialPacketNumber,
-		getMaxPacketSize(s.conn.RemoteAddr()),
+		getMaxPacketSize(s.conn.RemoteAddr(), s.version),
 		s.rttStats,
 		false, /* has no effect */
 		s.perspective,
 		s.tracer,
 		s.logger,
 	)
-	s.mtuDiscoverer = newMTUDiscoverer(s.rttStats, getMaxPacketSize(s.conn.RemoteAddr()), s.sentPacketHandler.SetMaxDatagramSize)
+	s.mtuDiscoverer = newMTUDiscoverer(s.rttStats, getMaxPacketSize(s.conn.RemoteAddr(), s.version), s.sentPacketHandler.SetMaxDatagramSize)
 	oneRTTStream := newCryptoStream()
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiRemote: protocol.ByteCount(s.config.InitialStreamReceiveWindow),

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -67,6 +67,10 @@ const MaxLargePacketBufferSize = 20 * 1024
 // MinInitialPacketSize is the minimum size an Initial packet is required to have.
 const MinInitialPacketSize = 1200
 
+// MinSCIONInitialPacketSize is the minimum size an Initial packet is required to have
+// in the SCION version of the protocol.
+const MinSCIONInitialPacketSize = 600
+
 // MinUnknownVersionPacketSize is the minimum size a packet with an unknown version
 // needs to have in order to trigger a Version Negotiation packet.
 const MinUnknownVersionPacketSize = MinInitialPacketSize

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -22,11 +22,37 @@ const (
 	versionDraft29 VersionNumber = 0xff00001d // draft-29 used to be a widely deployed version
 	Version1       VersionNumber = 0x1
 	Version2       VersionNumber = 0x6b3343cf
+
+	VersionSCIONExperimental VersionNumber = 0x5c10000f
 )
 
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
 var SupportedVersions = []VersionNumber{Version1, Version2}
+
+// NativelySupportedVersions lists the versions that are natively
+// supported by upstream quic-go.
+var NativelySupportedVersions []VersionNumber
+
+// Use init method to avoid merge conflicts.
+func init() {
+	NativelySupportedVersions = append([]VersionNumber(nil), SupportedVersions...)
+
+	// Prefer the native versions over SCIONExperimental to keep the default
+	// configuration backwards compatible.
+	SupportedVersions = append(SupportedVersions, VersionSCIONExperimental)
+}
+
+func IsSCIONVersion(v VersionNumber) bool {
+	return v >= 0x5c100000 && v <= 0x5c10000f
+}
+
+func GetMinInitialPacketSize(v VersionNumber) ByteCount {
+	if IsSCIONVersion(v) {
+		return MinSCIONInitialPacketSize
+	}
+	return MinInitialPacketSize
+}
 
 // IsValidVersion says if the version is known to quic-go
 func IsValidVersion(v VersionNumber) bool {
@@ -40,6 +66,8 @@ func (vn VersionNumber) String() string {
 		return "unknown"
 	case versionDraft29:
 		return "draft-29"
+	case VersionSCIONExperimental:
+		return "scion-experimental"
 	case Version1:
 		return "v1"
 	case Version2:

--- a/mtu_discoverer.go
+++ b/mtu_discoverer.go
@@ -27,8 +27,8 @@ const (
 	mtuProbeDelay = 5
 )
 
-func getMaxPacketSize(addr net.Addr) protocol.ByteCount {
-	maxSize := protocol.ByteCount(protocol.MinInitialPacketSize)
+func getMaxPacketSize(addr net.Addr, version protocol.VersionNumber) protocol.ByteCount {
+	maxSize := protocol.GetMinInitialPacketSize(version)
 	// If this is not a UDP address, we don't know anything about the MTU.
 	// Use the minimum size of an Initial packet as the max packet size.
 	if udpAddr, ok := addr.(*net.UDPAddr); ok {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -102,18 +102,18 @@ var _ = Describe("Packet packer", func() {
 
 	Context("determining the maximum packet size", func() {
 		It("uses the minimum initial size, if it can't determine if the remote address is IPv4 or IPv6", func() {
-			Expect(getMaxPacketSize(&net.TCPAddr{})).To(BeEquivalentTo(protocol.MinInitialPacketSize))
+			Expect(getMaxPacketSize(&net.TCPAddr{}, protocol.Version1)).To(BeEquivalentTo(protocol.MinInitialPacketSize))
 		})
 
 		It("uses the maximum IPv4 packet size, if the remote address is IPv4", func() {
 			addr := &net.UDPAddr{IP: net.IPv4(11, 12, 13, 14), Port: 1337}
-			Expect(getMaxPacketSize(addr)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv4))
+			Expect(getMaxPacketSize(addr, protocol.Version1)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv4))
 		})
 
 		It("uses the maximum IPv6 packet size, if the remote address is IPv6", func() {
 			ip := net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
 			addr := &net.UDPAddr{IP: ip, Port: 1337}
-			Expect(getMaxPacketSize(addr)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv6))
+			Expect(getMaxPacketSize(addr, protocol.Version1)).To(BeEquivalentTo(protocol.InitialPacketSizeIPv6))
 		})
 	})
 

--- a/server.go
+++ b/server.go
@@ -417,7 +417,7 @@ func (s *baseServer) handlePacketImpl(p receivedPacket) bool /* is the buffer st
 		s.logger.Debugf("Error parsing packet: %s", err)
 		return false
 	}
-	if hdr.Type == protocol.PacketTypeInitial && p.Size() < protocol.MinInitialPacketSize {
+	if hdr.Type == protocol.PacketTypeInitial && p.Size() < protocol.GetMinInitialPacketSize(hdr.Version) {
 		s.logger.Debugf("Dropping a packet that is too small to be a valid Initial (%d bytes)", p.Size())
 		if s.tracer != nil {
 			s.tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeInitial, p.Size(), logging.PacketDropUnexpectedPacket)


### PR DESCRIPTION
1. Introduction of the new version number
2. In SCION version of the protocol minimal initial packet size is reduced from 1200B to 600B

includes #1, #2, #3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/quic-go/4)
<!-- Reviewable:end -->
